### PR TITLE
Add full-stack prototype for training recommendations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL="file:./dev.db"
+OPENAI_API_KEY=""
+GEMINI_API_KEY=""

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+*.log
+npm-debug.log*
+pnpm-lock.yaml
+yarn.lock
+apps/backend/dist/
+apps/frontend/dist/
+packages/mastra-core/dist/
+packages/mastra-llamaindex/dist/
+.dev.db*
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# kenshu-matcher
+# Kenshu Matcher
+
+B2B 向けに、従業員のキャリア目標に合った研修をおすすめする AI 支援型のプロトタイプです。人事向けダッシュボードと従業員向けキャリアプランナーを提供します。
+
+## 技術構成
+
+- フロントエンド: Vite + React + TypeScript
+- バックエンド: Express + TypeScript + (ローカル実装の) Mastra 互換モジュール
+- データベース: Prisma + SQLite
+- Lint: TSLint (any 禁止・型定義必須)
+
+## セットアップ
+
+```bash
+npm install
+npm run build
+```
+
+`.env` をルートに作成してください (`.env.example` をコピー)。
+
+- `DATABASE_URL` には `file:./dev.db` を指定するとリポジトリ直下に SQLite ファイルが生成されます。
+- `OPENAI_API_KEY`、`GEMINI_API_KEY` に API キーを設定すると、AI 推薦要約に各モデルを利用します。未設定の場合はヒューリスティックに基づく要約を返します。
+
+Prisma クライアントの生成とマイグレーションを実行します。
+
+```bash
+npm run prisma:generate --workspace apps/backend
+npm run prisma:migrate --workspace apps/backend -- "dev --name init"
+```
+
+開発サーバーは以下で同時起動します。
+
+```bash
+npm run dev
+```
+
+- フロントエンド: http://localhost:5173
+- バックエンド API: http://localhost:4000
+
+## テストデータ
+
+バックエンド起動時に YouTube 検索リンクを含む研修データとスキルが自動投入されます。
+
+## Lint
+
+```bash
+npm run lint
+```
+
+## 主なフォルダ構成
+
+```
+apps/
+  frontend/   # React + Vite フロントエンド
+  backend/    # Express + Prisma バックエンド
+packages/
+  mastra-*    # AI 連携のための Mastra 互換ローカル実装
+prisma/       # Prisma スキーマ
+```

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "kenshu-matcher-backend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "lint": "tslint -p tsconfig.json -c tslint.json 'src/**/*.ts'",
+    "prisma:generate": "prisma generate --schema ../../prisma/schema.prisma",
+    "prisma:migrate": "prisma migrate",
+    "prisma:studio": "prisma studio"
+  },
+  "dependencies": {
+    "@mastra/core": "file:../../packages/mastra-core",
+    "@mastra/llamaindex": "file:../../packages/mastra-llamaindex",
+    "@prisma/client": "^5.16.1",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "prisma": "^5.16.1"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.14.10",
+    "ts-node": "^10.9.2",
+    "tslint": "^6.1.3",
+    "typescript": "^5.5.4",
+    "tsx": "^4.16.2"
+  }
+}

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -1,0 +1,9 @@
+import { config as loadEnv } from 'dotenv';
+import path from 'path';
+
+loadEnv({ path: path.resolve(process.cwd(), '../../.env') });
+
+export const PORT = Number(process.env.PORT ?? '4000');
+export const OPENAI_API_KEY = process.env.OPENAI_API_KEY ?? '';
+export const GEMINI_API_KEY = process.env.GEMINI_API_KEY ?? '';
+export const DATABASE_URL = process.env.DATABASE_URL ?? 'file:./dev.db';

--- a/apps/backend/src/routes/dashboardRoute.ts
+++ b/apps/backend/src/routes/dashboardRoute.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { getHrDashboard } from '../services/dashboardService';
+
+const dashboardRoute = Router();
+
+dashboardRoute.get('/', async (_request, response) => {
+  const dashboard = await getHrDashboard();
+  response.json(dashboard);
+});
+
+export default dashboardRoute;

--- a/apps/backend/src/routes/recommendationRoute.ts
+++ b/apps/backend/src/routes/recommendationRoute.ts
@@ -1,0 +1,35 @@
+import { Router } from 'express';
+import recommendationService from '../services/recommendationService';
+import { RecommendationRequestBody } from '../types';
+
+const recommendationRoute = Router();
+
+const isValidRequest = (body: RecommendationRequestBody | undefined): body is RecommendationRequestBody => {
+  return (
+    body !== undefined &&
+    Array.isArray(body.goals) &&
+    body.goals.length > 0 &&
+    Array.isArray(body.focusSkillIds)
+  );
+};
+
+recommendationRoute.post('/', async (request, response) => {
+  const body = request.body as RecommendationRequestBody | undefined;
+
+  if (!isValidRequest(body)) {
+    response.status(400).json({ message: 'Invalid request body' });
+    return;
+  }
+
+  try {
+    const result = await recommendationService.generateRecommendation(body);
+    response.json(result);
+  } catch (error) {
+    response.status(500).json({
+      message: 'Failed to generate recommendation',
+      detail: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+});
+
+export default recommendationRoute;

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -1,0 +1,26 @@
+import express from 'express';
+import { PORT } from './config';
+import recommendationRoute from './routes/recommendationRoute';
+import dashboardRoute from './routes/dashboardRoute';
+import { ensureSeedData } from './services/catalogService';
+
+const bootstrap = async (): Promise<void> => {
+  await ensureSeedData();
+
+  const app = express();
+  app.use(express.json());
+
+  app.get('/health', (_request, response) => {
+    response.json({ status: 'ok' });
+  });
+
+  app.use('/api/recommendations', recommendationRoute);
+  app.use('/api/hr-dashboard', dashboardRoute);
+
+  app.listen(PORT, () => {
+    // eslint-disable-next-line no-console
+    console.error(`API server is running at http://localhost:${PORT}`);
+  });
+};
+
+void bootstrap();

--- a/apps/backend/src/services/catalogService.ts
+++ b/apps/backend/src/services/catalogService.ts
@@ -1,0 +1,114 @@
+import prisma from '../utils/prisma';
+
+export const ensureSeedData = async (): Promise<void> => {
+  const skillCount = await prisma.skill.count();
+  if (skillCount > 0) {
+    return;
+  }
+
+  const skills = await prisma.$transaction(
+    [
+      prisma.skill.create({ data: { name: '国際取引' } }),
+      prisma.skill.create({ data: { name: '交渉力' } }),
+      prisma.skill.create({ data: { name: '財務分析' } }),
+      prisma.skill.create({ data: { name: 'データ分析' } }),
+      prisma.skill.create({ data: { name: 'プロジェクト管理' } }),
+      prisma.skill.create({ data: { name: 'デジタルマーケティング' } }),
+      prisma.skill.create({ data: { name: 'ESG' } }),
+      prisma.skill.create({ data: { name: 'ステークホルダーマネジメント' } }),
+      prisma.skill.create({ data: { name: '新規事業開発' } })
+    ]
+  );
+
+  const trainings = await prisma.$transaction(
+    [
+      prisma.training.create({
+        data: {
+          title: '国際取引の基礎 - YouTube 講座',
+          description: '貿易実務と契約の基本を分かりやすく解説',
+          url: 'https://www.youtube.com/results?search_query=%E5%9B%BD%E9%9A%9B%E5%8F%96%E5%BC%95+%E5%9F%BA%E7%A4%8E',
+          source: 'YouTube'
+        }
+      }),
+      prisma.training.create({
+        data: {
+          title: '交渉力を鍛えるケーススタディ',
+          description: '実践的な交渉フレームワークと商談の進め方',
+          url: 'https://www.youtube.com/results?search_query=%E4%BA%A4%E6%B8%89%E5%8A%9B+%E5%95%86%E7%A4%BE',
+          source: 'YouTube'
+        }
+      }),
+      prisma.training.create({
+        data: {
+          title: '財務三表を読み解く',
+          description: '営業に必要な財務分析スキルを習得',
+          url: 'https://www.youtube.com/results?search_query=%E8%B2%A1%E5%8B%99%E5%88%86%E6%9E%90+%E5%95%86%E7%A4%BE',
+          source: 'YouTube'
+        }
+      }),
+      prisma.training.create({
+        data: {
+          title: 'データ分析入門',
+          description: 'Excel と BI ツールを用いた分析プロセス',
+          url: 'https://www.youtube.com/results?search_query=%E3%83%87%E3%83%BC%E3%82%BF%E5%88%86%E6%9E%90+DX',
+          source: 'YouTube'
+        }
+      }),
+      prisma.training.create({
+        data: {
+          title: 'プロジェクトマネジメント実践',
+          description: '商社の DX プロジェクトを成功させるコツ',
+          url: 'https://www.youtube.com/results?search_query=%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E7%AE%A1%E7%90%86+DX',
+          source: 'YouTube'
+        }
+      }),
+      prisma.training.create({
+        data: {
+          title: 'デジタルマーケティングで案件創出',
+          description: 'B2B マーケティングにおけるリード獲得手法',
+          url: 'https://www.youtube.com/results?search_query=B2B+%E3%83%87%E3%82%B8%E3%82%BF%E3%83%AB%E3%83%9E%E3%83%BC%E3%82%B1%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0',
+          source: 'YouTube'
+        }
+      }),
+      prisma.training.create({
+        data: {
+          title: 'ESG 経営の最前線',
+          description: 'サステナビリティを事業戦略に取り込むポイント',
+          url: 'https://www.youtube.com/results?search_query=ESG+%E7%AE%A1%E7%90%86',
+          source: 'YouTube'
+        }
+      }),
+      prisma.training.create({
+        data: {
+          title: 'ステークホルダーを巻き込むコミュニケーション',
+          description: '社内外の関係者との合意形成をリードする',
+          url: 'https://www.youtube.com/results?search_query=%E3%82%B9%E3%83%86%E3%83%BC%E3%82%AF%E3%83%9B%E3%83%AB%E3%83%80%E3%83%BC+%E3%82%B3%E3%83%9F%E3%83%A5%E3%83%8B%E3%82%B1%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3',
+          source: 'YouTube'
+        }
+      }),
+      prisma.training.create({
+        data: {
+          title: '新規事業開発の実践フレーム',
+          description: '市場調査から事業化までのプロセスを学ぶ',
+          url: 'https://www.youtube.com/results?search_query=%E6%96%B0%E8%A6%8F%E4%BA%8B%E6%A5%AD%E9%96%8B%E7%99%BA+%E5%95%86%E7%A4%BE',
+          source: 'YouTube'
+        }
+      })
+    ]
+  );
+
+  await prisma.$transaction(
+    trainings.flatMap((training, index) =>
+      (skills[index] !== undefined
+        ? [
+            prisma.trainingSkill.create({
+              data: {
+                trainingId: training.id,
+                skillId: skills[index]?.id ?? skills[0]?.id ?? 0
+              }
+            })
+          ]
+        : [])
+    )
+  );
+};

--- a/apps/backend/src/services/dashboardService.ts
+++ b/apps/backend/src/services/dashboardService.ts
@@ -1,0 +1,52 @@
+import { HrDashboardResponse } from '../types';
+
+export const getHrDashboard = async (): Promise<HrDashboardResponse> => {
+  return {
+    goals: [
+      {
+        id: 'global-sales',
+        title: 'グローバル営業体制の強化',
+        description: '海外営業チームの大型案件獲得を加速する',
+        progress: 62,
+        focusSkills: ['国際取引', '交渉力', '財務分析']
+      },
+      {
+        id: 'dx-promotion',
+        title: 'DX 推進による業務改革',
+        description: '部門横断のデジタルプロジェクトを内製化',
+        progress: 48,
+        focusSkills: ['データ分析', 'プロジェクト管理', 'デジタルマーケティング']
+      },
+      {
+        id: 'sustainability',
+        title: 'サステナビリティ経営の実装',
+        description: 'ESG を意識した新規ビジネス創出を目指す',
+        progress: 35,
+        focusSkills: ['ESG', 'ステークホルダーマネジメント', '新規事業開発']
+      }
+    ],
+    employees: [
+      {
+        id: 'employee-1',
+        name: '山田 花子',
+        currentRole: '法人営業',
+        targetRole: 'グローバルアカウントマネージャー',
+        readiness: 55
+      },
+      {
+        id: 'employee-2',
+        name: '田中 太郎',
+        currentRole: '事業開発',
+        targetRole: 'サステナビリティ戦略リード',
+        readiness: 42
+      },
+      {
+        id: 'employee-3',
+        name: '佐藤 京子',
+        currentRole: 'DX 推進室',
+        targetRole: 'デジタル戦略ディレクター',
+        readiness: 68
+      }
+    ]
+  };
+};

--- a/apps/backend/src/services/recommendationService.ts
+++ b/apps/backend/src/services/recommendationService.ts
@@ -1,0 +1,110 @@
+import { Mastra } from '@mastra/core';
+import { createFallbackProvider, createGeminiProvider, createOpenAiProvider } from '@mastra/llamaindex';
+import { Training, TrainingSkill } from '@prisma/client';
+import { GEMINI_API_KEY, OPENAI_API_KEY } from '../config';
+import prisma from '../utils/prisma';
+import { RecommendationPayload, RecommendationRequestBody } from '../types';
+
+interface TrainingWithSkills extends Training {
+  readonly skills: readonly (TrainingSkill & {
+    readonly skill: {
+      readonly name: string;
+    };
+  })[];
+}
+
+const buildPrompt = (request: RecommendationRequestBody, trainings: readonly TrainingWithSkills[]): string => {
+  const employeeSection = request.employeeProfile
+    ? `名前: ${request.employeeProfile.name}\n現職: ${request.employeeProfile.currentRole}\nキャリア展望: ${request.employeeProfile.aspiration}\n強み: ${request.employeeProfile.strengths.join(', ')}\n伸ばしたい領域: ${request.employeeProfile.growthAreas.join(', ')}`
+    : '従業員情報: 指定なし';
+
+  const goalDescriptions = request.goals
+    .map((goal) => `${goal.title}: ${goal.description} / スキル: ${goal.targetSkills.join(', ')}`)
+    .join('\n');
+
+  const trainingOptions = trainings
+    .map((training) => `- ${training.title}: ${training.description} / スキル: ${training.skills.map((skill) => skill.skill.name).join(', ')}`)
+    .join('\n');
+
+  return `以下の従業員とキャリアゴールに対して、上位 3 件の研修を推奨し、理由と期待効果を日本語で 120 文字程度にまとめてください。\n従業員:\n${employeeSection}\n\nキャリアゴール:\n${goalDescriptions}\n\n利用可能な研修候補:\n${trainingOptions}`;
+};
+
+const createFallbackSummary = (request: RecommendationRequestBody): string => {
+  const goalTitles = request.goals.map((goal) => goal.title).join('、');
+  return `目標「${goalTitles}」に向けて、重点スキルを段階的に強化できる研修を提案しました。スキル習得後は現場での実践と振り返りを組み合わせて定着を図りましょう。`;
+};
+
+class RecommendationService {
+  private readonly mastra: Mastra;
+
+  public constructor() {
+    const providers = [createFallbackProvider(() => '')];
+
+    if (OPENAI_API_KEY.length > 0) {
+      providers.unshift(
+        createOpenAiProvider({
+          apiKey: OPENAI_API_KEY,
+          model: 'gpt-4o-mini'
+        })
+      );
+    }
+
+    if (GEMINI_API_KEY.length > 0) {
+      providers.unshift(
+        createGeminiProvider({
+          apiKey: GEMINI_API_KEY,
+          model: 'gemini-1.5-flash-latest'
+        })
+      );
+    }
+
+    this.mastra = new Mastra({ providers });
+  }
+
+  public async generateRecommendation(request: RecommendationRequestBody): Promise<RecommendationPayload> {
+    const focusSkillSet = new Set(request.focusSkillIds);
+
+    const trainings = await prisma.training.findMany({
+      include: {
+        skills: {
+          include: {
+            skill: true
+          }
+        }
+      }
+    });
+
+    const enrichedTrainings = trainings as unknown as TrainingWithSkills[];
+
+    const scored = enrichedTrainings
+      .map((training) => {
+        const matchedSkills = training.skills.filter((skill) => focusSkillSet.has(skill.skill.name));
+        const score = Math.min(100, matchedSkills.length * 30 + 40);
+        return {
+          training,
+          score
+        };
+      })
+      .sort((left, right) => right.score - left.score)
+      .slice(0, 3);
+
+    const aiPrompt = buildPrompt(request, scored.map((item) => item.training));
+    const aiResult = await this.mastra.run(aiPrompt);
+    const summary = aiResult.output.length > 0 ? aiResult.output : createFallbackSummary(request);
+
+    return {
+      summary,
+      trainings: scored.map((item, index) => ({
+        id: `${item.training.id}`,
+        title: item.training.title,
+        description: item.training.description,
+        url: item.training.url,
+        relevance: Math.min(100, item.score + (2 - index) * 5)
+      }))
+    };
+  }
+}
+
+const recommendationService = new RecommendationService();
+
+export default recommendationService;

--- a/apps/backend/src/types/index.ts
+++ b/apps/backend/src/types/index.ts
@@ -1,0 +1,55 @@
+export interface CareerGoal {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly targetSkills: readonly string[];
+}
+
+export interface EmployeeProfile {
+  readonly name: string;
+  readonly currentRole: string;
+  readonly aspiration: string;
+  readonly strengths: readonly string[];
+  readonly growthAreas: readonly string[];
+}
+
+export interface RecommendationRequestBody {
+  readonly persona: 'hr' | 'employee';
+  readonly goals: readonly CareerGoal[];
+  readonly focusSkillIds: readonly string[];
+  readonly employeeProfile?: EmployeeProfile;
+}
+
+export interface TrainingRecommendation {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly url: string;
+  readonly relevance: number;
+}
+
+export interface RecommendationPayload {
+  readonly summary: string;
+  readonly trainings: readonly TrainingRecommendation[];
+}
+
+export interface DashboardGoal {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly progress: number;
+  readonly focusSkills: readonly string[];
+}
+
+export interface DashboardEmployee {
+  readonly id: string;
+  readonly name: string;
+  readonly currentRole: string;
+  readonly targetRole: string;
+  readonly readiness: number;
+}
+
+export interface HrDashboardResponse {
+  readonly goals: readonly DashboardGoal[];
+  readonly employees: readonly DashboardEmployee[];
+}

--- a/apps/backend/src/utils/prisma.ts
+++ b/apps/backend/src/utils/prisma.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from '@prisma/client';
+
+const prismaClient: PrismaClient = new PrismaClient();
+
+export default prismaClient;

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/apps/backend/tslint.json
+++ b/apps/backend/tslint.json
@@ -1,0 +1,20 @@
+{
+  "defaultSeverity": "error",
+  "extends": ["tslint:recommended"],
+  "rules": {
+    "typedef": [
+      true,
+      "call-signature",
+      "parameter",
+      "arrow-parameter",
+      "property-declaration",
+      "member-variable-declaration",
+      "object-destructuring"
+    ],
+    "interface-name": [true, "never-prefix"],
+    "no-console": [true, "log"],
+    "object-literal-sort-keys": false,
+    "no-implicit-dependencies": false,
+    "no-any": true
+  }
+}

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>商社向け研修マッチング</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "kenshu-matcher-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "tslint -p tsconfig.json -c tslint.json 'src/**/*.ts' 'src/**/*.tsx'"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.59.15",
+    "axios": "^1.7.3",
+    "clsx": "^2.1.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "tslint": "^6.1.3",
+    "tslint-react": "^5.0.0",
+    "typescript": "^5.5.4",
+    "vite": "^5.3.4"
+  }
+}

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+import { Persona } from './types';
+import PersonaTabs from './components/PersonaTabs';
+import HrDashboard from './components/HrDashboard';
+import EmployeePlanner from './components/EmployeePlanner';
+
+const App = (): JSX.Element => {
+  const [persona, setPersona] = useState<Persona>('hr');
+
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <h1>商社向け研修マッチング</h1>
+        <p className="subtitle">従業員のキャリアに合わせた研修プランを AI が提案します</p>
+      </header>
+      <PersonaTabs selected={persona} onSelect={setPersona} />
+      <main className="app-main">
+        {persona === 'hr' ? <HrDashboard /> : <EmployeePlanner />}
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/apps/frontend/src/components/EmployeePlanner.tsx
+++ b/apps/frontend/src/components/EmployeePlanner.tsx
@@ -1,0 +1,148 @@
+import { FormEvent, useMemo, useState } from 'react';
+import { CareerGoal, RecommendationRequest } from '../types';
+import { useRecommendationMutation } from '../hooks/useRecommendations';
+import TrainingList from './TrainingList';
+
+interface FormState {
+  readonly name: string;
+  readonly currentRole: string;
+  readonly aspiration: string;
+  readonly strengths: string;
+  readonly growthAreas: string;
+  readonly selectedGoalId: string;
+}
+
+const GOALS: readonly CareerGoal[] = [
+  {
+    id: 'trading-specialist',
+    title: 'トレーディングスペシャリスト',
+    description: '商品知識と交渉スキルを高めて大型案件を獲得する',
+    targetSkills: ['国際取引', '交渉力', '財務分析']
+  },
+  {
+    id: 'digital-strategist',
+    title: 'デジタル戦略担当',
+    description: 'DX 推進をリードし、全社の業務効率化を実現する',
+    targetSkills: ['データ分析', 'プロジェクト管理', 'デジタルマーケティング']
+  },
+  {
+    id: 'sustainability-lead',
+    title: 'サステナビリティリード',
+    description: 'ESG 観点での新規事業開発を牽引する',
+    targetSkills: ['ESG', 'ステークホルダーマネジメント', '新規事業開発']
+  }
+];
+
+const createInitialState = (): FormState => ({
+  name: '山田 花子',
+  currentRole: '法人営業',
+  aspiration: 'グローバル案件をリードできる営業マネージャーになりたい',
+  strengths: '顧客折衝, 問題解決',
+  growthAreas: '財務知識, 英語プレゼン',
+  selectedGoalId: GOALS[0]?.id ?? ''
+});
+
+const EmployeePlanner = (): JSX.Element => {
+  const [formState, setFormState] = useState<FormState>(createInitialState);
+  const recommendationMutation = useRecommendationMutation();
+
+  const selectedGoal: CareerGoal | undefined = useMemo(
+    () => GOALS.find((goal) => goal.id === formState.selectedGoalId),
+    [formState.selectedGoalId]
+  );
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
+    event.preventDefault();
+    if (selectedGoal === undefined) {
+      return;
+    }
+
+    const payload: RecommendationRequest = {
+      persona: 'employee',
+      goals: [selectedGoal],
+      focusSkillIds: selectedGoal.targetSkills,
+      employeeProfile: {
+        name: formState.name,
+        currentRole: formState.currentRole,
+        aspiration: formState.aspiration,
+        strengths: formState.strengths.split(',').map((item) => item.trim()).filter((item) => item.length > 0),
+        growthAreas: formState.growthAreas.split(',').map((item) => item.trim()).filter((item) => item.length > 0)
+      }
+    };
+
+    await recommendationMutation.mutateAsync(payload);
+  };
+
+  return (
+    <div className="panel">
+      <h2>キャリアプラン作成</h2>
+      <form className="form" onSubmit={handleSubmit}>
+        <label>
+          氏名
+          <input
+            value={formState.name}
+            onChange={(event) => setFormState({ ...formState, name: event.target.value })}
+            required
+          />
+        </label>
+        <label>
+          現在の役割
+          <input
+            value={formState.currentRole}
+            onChange={(event) => setFormState({ ...formState, currentRole: event.target.value })}
+            required
+          />
+        </label>
+        <label>
+          キャリア展望
+          <textarea
+            value={formState.aspiration}
+            onChange={(event) => setFormState({ ...formState, aspiration: event.target.value })}
+            rows={3}
+          />
+        </label>
+        <label>
+          強み (カンマ区切り)
+          <input
+            value={formState.strengths}
+            onChange={(event) => setFormState({ ...formState, strengths: event.target.value })}
+          />
+        </label>
+        <label>
+          伸ばしたい領域 (カンマ区切り)
+          <input
+            value={formState.growthAreas}
+            onChange={(event) => setFormState({ ...formState, growthAreas: event.target.value })}
+          />
+        </label>
+        <label>
+          目標ロール
+          <select
+            value={formState.selectedGoalId}
+            onChange={(event) => setFormState({ ...formState, selectedGoalId: event.target.value })}
+          >
+            {GOALS.map((goal) => (
+              <option key={goal.id} value={goal.id}>
+                {goal.title}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button type="submit" disabled={recommendationMutation.isPending}>
+          {recommendationMutation.isPending ? 'AI が分析中...' : '研修を提案してもらう'}
+        </button>
+      </form>
+      {recommendationMutation.data !== undefined && (
+        <TrainingList
+          trainings={recommendationMutation.data.trainings}
+          summary={recommendationMutation.data.summary}
+        />
+      )}
+      {recommendationMutation.error !== undefined && (
+        <p className="error">提案の生成中に問題が発生しました</p>
+      )}
+    </div>
+  );
+};
+
+export default EmployeePlanner;

--- a/apps/frontend/src/components/HrDashboard.tsx
+++ b/apps/frontend/src/components/HrDashboard.tsx
@@ -1,0 +1,60 @@
+import { useMemo } from 'react';
+import { useHrDashboard } from '../hooks/useRecommendations';
+
+const HrDashboard = (): JSX.Element => {
+  const { data, isLoading, error } = useHrDashboard();
+
+  const averageProgress: number = useMemo(() => {
+    if (!data?.goals.length) {
+      return 0;
+    }
+    const totalProgress = data.goals.reduce((accumulator: number, goal) => accumulator + goal.progress, 0);
+    return Math.round(totalProgress / data.goals.length);
+  }, [data]);
+
+  if (isLoading) {
+    return <p>読み込み中...</p>;
+  }
+
+  if (error !== undefined) {
+    return <p className="error">ダッシュボードの取得中にエラーが発生しました</p>;
+  }
+
+  return (
+    <div className="panel-grid">
+      <section className="panel">
+        <h2>優先キャリアゴール</h2>
+        <p className="metric">平均進捗 {averageProgress}%</p>
+        <ul className="list">
+          {data?.goals.map((goal) => (
+            <li key={goal.id}>
+              <h3>{goal.title}</h3>
+              <p>{goal.description}</p>
+              <p className="tagline">注力スキル: {goal.focusSkills.join(', ')}</p>
+              <progress value={goal.progress} max={100} />
+            </li>
+          ))}
+        </ul>
+      </section>
+      <section className="panel">
+        <h2>従業員のサクセッション</h2>
+        <ul className="list">
+          {data?.employees.map((employee) => (
+            <li key={employee.id}>
+              <div className="list-header">
+                <div>
+                  <h3>{employee.name}</h3>
+                  <p className="tagline">現職: {employee.currentRole} / 目標: {employee.targetRole}</p>
+                </div>
+                <span className="badge">準備度 {employee.readiness}%</span>
+              </div>
+              <progress value={employee.readiness} max={100} />
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+export default HrDashboard;

--- a/apps/frontend/src/components/PersonaTabs.tsx
+++ b/apps/frontend/src/components/PersonaTabs.tsx
@@ -1,0 +1,29 @@
+import { Persona } from '../types';
+
+interface PersonaTabsProps {
+  readonly selected: Persona;
+  readonly onSelect: (persona: Persona) => void;
+}
+
+const PersonaTabs = ({ selected, onSelect }: PersonaTabsProps): JSX.Element => {
+  return (
+    <div className="tab-container">
+      <button
+        type="button"
+        className={`tab ${selected === 'hr' ? 'active' : ''}`}
+        onClick={(): void => onSelect('hr')}
+      >
+        人事向けビュー
+      </button>
+      <button
+        type="button"
+        className={`tab ${selected === 'employee' ? 'active' : ''}`}
+        onClick={(): void => onSelect('employee')}
+      >
+        従業員向けビュー
+      </button>
+    </div>
+  );
+};
+
+export default PersonaTabs;

--- a/apps/frontend/src/components/TrainingList.tsx
+++ b/apps/frontend/src/components/TrainingList.tsx
@@ -1,0 +1,33 @@
+import { TrainingRecommendation } from '../types';
+
+interface TrainingListProps {
+  readonly trainings: readonly TrainingRecommendation[];
+  readonly summary: string;
+}
+
+const TrainingList = ({ trainings, summary }: TrainingListProps): JSX.Element => {
+  return (
+    <section className="panel">
+      <h2>AI 推薦結果</h2>
+      <p className="summary">{summary}</p>
+      <ul className="list">
+        {trainings.map((training) => (
+          <li key={training.id}>
+            <div className="list-header">
+              <div>
+                <h3>{training.title}</h3>
+                <p className="tagline">関連度: {training.relevance}%</p>
+              </div>
+              <a href={training.url} target="_blank" rel="noreferrer" className="badge">
+                視聴する
+              </a>
+            </div>
+            <p>{training.description}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default TrainingList;

--- a/apps/frontend/src/hooks/useRecommendations.ts
+++ b/apps/frontend/src/hooks/useRecommendations.ts
@@ -1,0 +1,46 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import { RecommendationRequest, RecommendationResponse } from '../types';
+
+interface DashboardResponse {
+  readonly goals: readonly {
+    readonly id: string;
+    readonly title: string;
+    readonly description: string;
+    readonly progress: number;
+    readonly focusSkills: readonly string[];
+  }[];
+  readonly employees: readonly {
+    readonly id: string;
+    readonly name: string;
+    readonly currentRole: string;
+    readonly targetRole: string;
+    readonly readiness: number;
+  }[];
+}
+
+export const useHrDashboard = (): {
+  readonly data: DashboardResponse | undefined;
+  readonly isLoading: boolean;
+  readonly error: unknown;
+} => {
+  const { data, isLoading, error } = useQuery<DashboardResponse>({
+    queryKey: ['hr-dashboard'],
+    queryFn: async () => {
+      const response = await axios.get<DashboardResponse>('/api/hr-dashboard');
+      return response.data;
+    }
+  });
+
+  return { data, isLoading, error };
+};
+
+export const useRecommendationMutation = (): ReturnType<typeof useMutation<RecommendationResponse, unknown, RecommendationRequest>> => {
+  return useMutation<RecommendationResponse, unknown, RecommendationRequest>({
+    mutationKey: ['recommendation'],
+    mutationFn: async (payload: RecommendationRequest) => {
+      const response = await axios.post<RecommendationResponse>('/api/recommendations', payload);
+      return response.data;
+    }
+  });
+};

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import App from './App';
+import './styles.css';
+
+const queryClient: QueryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -1,0 +1,175 @@
+:root {
+  font-family: 'Noto Sans JP', system-ui, sans-serif;
+  color: #1f2933;
+  background-color: #f5f7fa;
+  line-height: 1.5;
+}
+
+body,
+html,
+#root {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.app-shell {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.app-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.subtitle {
+  color: #52606d;
+}
+
+.tab-container {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+}
+
+.tab {
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid #d2d6dc;
+  background-color: white;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  font-weight: 600;
+}
+
+.tab.active {
+  background-color: #2563eb;
+  color: white;
+  border-color: #2563eb;
+}
+
+.app-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel {
+  background-color: white;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.panel-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.form {
+  display: grid;
+  gap: 1rem;
+}
+
+input,
+textarea,
+select,
+button {
+  font-family: inherit;
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid #d2d6dc;
+  background-color: #f8fafc;
+}
+
+button[type='submit'] {
+  background-color: #2563eb;
+  color: white;
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+button[type='submit']:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.tagline {
+  color: #52606d;
+  margin: 0.5rem 0;
+}
+
+.metric {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #2563eb;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #dbeafe;
+  color: #1d4ed8;
+  border-radius: 999px;
+  padding: 0.4rem 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.summary {
+  background-color: #f8fafc;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid #d2d6dc;
+}
+
+.error {
+  color: #b91c1c;
+}
+
+progress {
+  width: 100%;
+  height: 0.75rem;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+progress::-webkit-progress-bar {
+  background-color: #e5e7eb;
+}
+
+progress::-webkit-progress-value {
+  background-color: #2563eb;
+}
+
+progress::-moz-progress-bar {
+  background-color: #2563eb;
+}

--- a/apps/frontend/src/types/index.ts
+++ b/apps/frontend/src/types/index.ts
@@ -1,0 +1,36 @@
+export type Persona = 'hr' | 'employee';
+
+export interface CareerGoal {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly targetSkills: readonly string[];
+}
+
+export interface TrainingRecommendation {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly url: string;
+  readonly relevance: number;
+}
+
+export interface RecommendationRequest {
+  readonly persona: Persona;
+  readonly goals: readonly CareerGoal[];
+  readonly focusSkillIds: readonly string[];
+  readonly employeeProfile?: EmployeeProfile;
+}
+
+export interface EmployeeProfile {
+  readonly name: string;
+  readonly currentRole: string;
+  readonly aspiration: string;
+  readonly strengths: readonly string[];
+  readonly growthAreas: readonly string[];
+}
+
+export interface RecommendationResponse {
+  readonly trainings: readonly TrainingRecommendation[];
+  readonly summary: string;
+}

--- a/apps/frontend/src/vite-env.d.ts
+++ b/apps/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": "./src",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/apps/frontend/tslint.json
+++ b/apps/frontend/tslint.json
@@ -1,0 +1,30 @@
+{
+  "defaultSeverity": "error",
+  "extends": [
+    "tslint:recommended",
+    "tslint-react"
+  ],
+  "jsRules": {},
+  "rules": {
+    "typedef": [
+      true,
+      "call-signature",
+      "parameter",
+      "arrow-parameter",
+      "property-declaration",
+      "member-variable-declaration",
+      "object-destructuring"
+    ],
+    "interface-name": [true, "never-prefix"],
+    "no-console": [true, "log", "error"],
+    "no-submodule-imports": false,
+    "object-literal-sort-keys": false,
+    "jsx-boolean-value": [true, "never"],
+    "jsx-no-lambda": false,
+    "no-implicit-dependencies": false,
+    "max-classes-per-file": false,
+    "no-var-requires": true,
+    "no-any": true
+  },
+  "rulesDirectory": []
+}

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:4000',
+        changeOrigin: true
+      }
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "kenshu-matcher",
+  "private": true,
+  "workspaces": [
+    "packages/*",
+    "apps/frontend",
+    "apps/backend"
+  ],
+  "scripts": {
+    "lint": "npm run lint --workspace apps/frontend && npm run lint --workspace apps/backend",
+    "dev": "concurrently \"npm run dev --workspace apps/backend\" \"npm run dev --workspace apps/frontend\"",
+    "build": "npm run build --workspace packages/mastra-core && npm run build --workspace packages/mastra-llamaindex && npm run build --workspace apps/backend && npm run build --workspace apps/frontend"
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.2"
+  }
+}

--- a/packages/mastra-core/package.json
+++ b/packages/mastra-core/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@mastra/core",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "private": true,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4"
+  }
+}

--- a/packages/mastra-core/src/index.ts
+++ b/packages/mastra-core/src/index.ts
@@ -1,0 +1,33 @@
+export interface MastraProvider {
+  readonly name: string;
+  readonly call: (prompt: string) => Promise<string>;
+}
+
+export interface MastraConfig {
+  readonly providers: readonly MastraProvider[];
+}
+
+export class Mastra {
+  private readonly providers: readonly MastraProvider[];
+
+  public constructor(config: MastraConfig) {
+    this.providers = config.providers;
+  }
+
+  public async run(prompt: string): Promise<{ readonly output: string }> {
+    for (const provider of this.providers) {
+      try {
+        const result = await provider.call(prompt);
+        if (result.length > 0) {
+          return { output: result };
+        }
+      } catch {
+        // fall through to next provider
+      }
+    }
+
+    return {
+      output: ''
+    };
+  }
+}

--- a/packages/mastra-core/tsconfig.json
+++ b/packages/mastra-core/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/mastra-llamaindex/package.json
+++ b/packages/mastra-llamaindex/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@mastra/llamaindex",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "private": true,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4"
+  }
+}

--- a/packages/mastra-llamaindex/src/index.ts
+++ b/packages/mastra-llamaindex/src/index.ts
@@ -1,0 +1,124 @@
+import { MastraProvider } from '@mastra/core';
+
+interface OpenAiConfig {
+  readonly apiKey: string;
+  readonly model?: string;
+}
+
+interface GeminiConfig {
+  readonly apiKey: string;
+  readonly model?: string;
+}
+
+interface OpenAiChatChoice {
+  readonly message?: {
+    readonly content?: string;
+  };
+}
+
+interface OpenAiChatCompletionResponse {
+  readonly choices: readonly OpenAiChatChoice[];
+}
+
+interface GeminiCandidate {
+  readonly content?: {
+    readonly parts?: readonly {
+      readonly text?: string;
+    }[];
+  };
+}
+
+interface GeminiResponse {
+  readonly candidates?: readonly GeminiCandidate[];
+}
+
+const readResponseText = async (response: Response): Promise<string> => {
+  const payload = (await response.json()) as unknown;
+  if (typeof payload !== 'object' || payload === null) {
+    return '';
+  }
+
+  if ('choices' in payload) {
+    const typed = payload as OpenAiChatCompletionResponse;
+    return typed.choices[0]?.message?.content ?? '';
+  }
+
+  if ('candidates' in payload) {
+    const typed = payload as GeminiResponse;
+    return typed.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+  }
+
+  return '';
+};
+
+export const createOpenAiProvider = (config: OpenAiConfig): MastraProvider => ({
+  name: 'openai',
+  call: async (prompt: string) => {
+    if (config.apiKey.length === 0) {
+      throw new Error('Missing OpenAI API key');
+    }
+
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${config.apiKey}`
+      },
+      body: JSON.stringify({
+        model: config.model ?? 'gpt-4o-mini',
+        messages: [
+          { role: 'system', content: 'You are a helpful career development assistant for Japanese trading companies.' },
+          { role: 'user', content: prompt }
+        ]
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error(`OpenAI error: ${response.status}`);
+    }
+
+    return readResponseText(response);
+  }
+});
+
+export const createGeminiProvider = (config: GeminiConfig): MastraProvider => ({
+  name: 'gemini',
+  call: async (prompt: string) => {
+    if (config.apiKey.length === 0) {
+      throw new Error('Missing Gemini API key');
+    }
+
+    const response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/${config.model ?? 'gemini-1.5-flash-latest'}:generateContent?key=${config.apiKey}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          contents: [
+            {
+              role: 'user',
+              parts: [
+                {
+                  text: prompt
+                }
+              ]
+            }
+          ]
+        })
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Gemini error: ${response.status}`);
+    }
+
+    return readResponseText(response);
+  }
+});
+
+export const createFallbackProvider = (generate: (prompt: string) => string): MastraProvider => ({
+  name: 'fallback',
+  call: async (prompt: string) => Promise.resolve(generate(prompt))
+});

--- a/packages/mastra-llamaindex/tsconfig.json
+++ b/packages/mastra-llamaindex/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,37 @@
+generator client {
+  provider = "prisma-client-js"
+  output   = "../apps/backend/node_modules/.prisma/client"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model Skill {
+  id        Int              @id @default(autoincrement())
+  name      String           @unique
+  createdAt DateTime         @default(now())
+  updatedAt DateTime         @updatedAt
+  trainings TrainingSkill[]
+}
+
+model Training {
+  id          Int              @id @default(autoincrement())
+  title       String
+  description String
+  url         String
+  source      String
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+  skills      TrainingSkill[]
+}
+
+model TrainingSkill {
+  training   Training @relation(fields: [trainingId], references: [id])
+  trainingId Int
+  skill      Skill    @relation(fields: [skillId], references: [id])
+  skillId    Int
+
+  @@id([trainingId, skillId])
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "lib": ["DOM", "DOM.Iterable", "ES2021"],
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Vite + React frontend with persona tabs for HR dashboard and employee planner flows
- implement Express + Prisma backend with Mastra-compatible AI orchestration and SQLite seed data
- add local Mastra shim packages, shared TypeScript configs, and setup docs/env templates

## Testing
- `npm run lint` *(fails: missing dependencies in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e37ccaeddc83328f236cf4e0439c2e